### PR TITLE
Use Into<String>

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tmflib"
-version = "0.1.5"
+version = "0.1.7"
 edition = "2021"
 authors = ["Ryan Ruckley <rruckley@gmail.com>"]
 description = "Interface library for processing TMF payloads"

--- a/examples/create_resource_candidate.rs
+++ b/examples/create_resource_candidate.rs
@@ -4,7 +4,7 @@
 use tmflib::tmf634::resource_candidate::ResourceCandidate;
 
 fn main() {
-    let rc = ResourceCandidate::new("My RC".into())
+    let rc = ResourceCandidate::new("My RC")
         .description("This is a description");
 
     dbg!(rc);

--- a/src/common/note.rs
+++ b/src/common/note.rs
@@ -18,7 +18,7 @@ pub struct Note {
 
 impl Note {
     /// Create a new note, without author
-    pub fn new(text : String) -> Note {
+    pub fn new(text : impl Into<String>) -> Note {
         let id = Uuid::new_v4().simple().to_string();
         let now = Utc::now();
         let time = NaiveDateTime::from_timestamp_opt(now.timestamp(), 0).unwrap();
@@ -26,7 +26,7 @@ impl Note {
             id, 
             author: None, 
             date: Some(time.to_string()), 
-            text : Some(text),
+            text : Some(text.into()),
         }
     }
     /// Set author for note with builder pattern

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,7 @@ pub trait HasLastUpdate {
     }
 
     /// Store a timestamp into last_update field (if available)
-    fn set_last_update(&mut self, time : String);
+    fn set_last_update(&mut self, time : impl Into<String>);
 }
 
 /// Trait to create a TMF struct including a timestamp field

--- a/src/tmf620/bundled_product_offering.rs
+++ b/src/tmf620/bundled_product_offering.rs
@@ -18,8 +18,8 @@ pub struct BundledProductOffering {
 
 impl BundledProductOffering {
     /// Create new options for BundledProductOffering
-    pub fn new(name: String) -> BundledProductOffering {
-        let mut offer = ProductOffering::new(name);
+    pub fn new(name: impl Into<String>) -> BundledProductOffering {
+        let mut offer = ProductOffering::new(name.into());
         // Update href to point to bundle instead of standard offer path
         let href = format!(
             "/{}/{}/{}/{}",

--- a/src/tmf620/catalog.rs
+++ b/src/tmf620/catalog.rs
@@ -50,8 +50,8 @@ pub struct Catalog {
 }
 
 impl HasLastUpdate for Catalog {
-    fn set_last_update(&mut self, time : String) {
-        self.last_update = Some(time);
+    fn set_last_update(&mut self, time : impl Into<String>) {
+        self.last_update = Some(time.into());
     }
 }
 
@@ -67,9 +67,9 @@ impl CreateTMFWithTime<Catalog> for Catalog {
 
 impl Catalog {
     /// Create a new instance of catalog struct
-    pub fn new(name : &str) -> Catalog {
+    pub fn new(name : impl Into<String>) -> Catalog {
         let mut cat = Catalog::create_with_time();
-        cat.name = Some(name.to_owned());
+        cat.name = Some(name.into());
         cat.version = Some(CAT_VERS.to_string());
         cat.category = Some(vec![]);
         cat.related_party = Some(vec![]);

--- a/src/tmf620/category.rs
+++ b/src/tmf620/category.rs
@@ -58,8 +58,8 @@ pub struct Category {
 }
 
 impl HasLastUpdate for Category {
-    fn set_last_update(&mut self, time : String) {
-        self.last_update = Some(time);
+    fn set_last_update(&mut self, time : impl Into<String>) {
+        self.last_update = Some(time.into());
     }
 }
 
@@ -78,10 +78,10 @@ impl Category {
     /// # use tmflib::tmf620::category::Category;
     /// let cat = Category::new(String::from("MyCategory"));
     /// ```
-    pub fn new(name: String) -> Category {
+    pub fn new(name: impl Into<String>) -> Category {
         let mut cat = Category::create_with_time();
         cat.version = Some(CAT_VERS.to_string());
-        cat.name = Some(name);
+        cat.name = Some(name.into());
         cat.is_root = Some(false);
         cat
     }

--- a/src/tmf620/product_offering.rs
+++ b/src/tmf620/product_offering.rs
@@ -191,8 +191,8 @@ impl HasId for ProductOffering {
 }
 
 impl HasLastUpdate for ProductOffering {
-    fn set_last_update(&mut self, time : String) {
-        self.last_update = Some(time);
+    fn set_last_update(&mut self, time : impl Into<String>) {
+        self.last_update = Some(time.into());
     }
 }
 impl CreateTMFWithTime<ProductOffering> for ProductOffering {}
@@ -204,9 +204,9 @@ impl ProductOffering {
     /// # use tmflib::tmf620::product_offering::ProductOffering;
     /// let po = ProductOffering::new(String::from("MyOffer"));
     /// ```
-    pub fn new(name: String) -> ProductOffering {
+    pub fn new(name: impl Into<String>) -> ProductOffering {
         let mut offer = ProductOffering::create_with_time();
-        offer.name = Some(name);
+        offer.name = Some(name.into());
         offer.version = Some(PO_VERS_INIT.to_string());
         offer.product_offering_relationship = Some(vec![]);
         offer.prod_spec_char_value_use = Some(vec![]);

--- a/src/tmf620/product_offering_price.rs
+++ b/src/tmf620/product_offering_price.rs
@@ -103,10 +103,10 @@ pub struct ProductOfferingPrice {
 
 impl ProductOfferingPrice {
     /// Create a new Price Offering Price object
-    pub fn new(name :  String) -> ProductOfferingPrice {
+    pub fn new(name :  impl Into<String>) -> ProductOfferingPrice {
         let mut pop = ProductOfferingPrice::create_with_time();
         pop.version = Some(PRICE_VERS.to_string());
-        pop.name = Some(name);
+        pop.name = Some(name.into());
         pop
     }
 }
@@ -142,7 +142,7 @@ impl HasName for ProductOfferingPrice {
 }
 
 impl HasLastUpdate for ProductOfferingPrice {
-    fn set_last_update(&mut self, time : String) {
-        self.last_update = Some(time);
+    fn set_last_update(&mut self, time : impl Into<String>) {
+        self.last_update = Some(time.into());
     }
 }

--- a/src/tmf620/product_specification.rs
+++ b/src/tmf620/product_specification.rs
@@ -41,12 +41,12 @@ impl ProductSpecificationCharacteristic {
     /// # use tmflib::tmf620::product_specification::ProductSpecificationCharacteristic;
     /// let ps_char = ProductSpecificationCharacteristic::new(String::from("My Characteristic"));
     /// ```
-    pub fn new(name: String) -> ProductSpecificationCharacteristic {
+    pub fn new(name: impl Into<String>) -> ProductSpecificationCharacteristic {
         ProductSpecificationCharacteristic {
             configurable: true,
             max_cardinality: CHAR_VALUE_MAX_CARD,
             min_cardinality: CHAR_VALUE_MIN_CARD,
-            name,
+            name : name.into(),
             ..Default::default()
         }
     }
@@ -143,9 +143,9 @@ pub struct ProductSpecification {
 
 impl ProductSpecification {
     /// Create new instance of Product Specification
-    pub fn new(name: String) -> ProductSpecification {       
+    pub fn new(name: impl Into<String>) -> ProductSpecification {       
         let mut prod_spec = ProductSpecification::create_with_time();
-        prod_spec.name = Some(name);
+        prod_spec.name = Some(name.into());
         prod_spec.version = Some(SPEC_VERS.to_string());
 
         prod_spec.product_spec_characteristic= Some(vec![]);
@@ -177,8 +177,8 @@ impl CreateTMF<ProductSpecification> for ProductSpecification {}
 impl CreateTMFWithTime<ProductSpecification> for ProductSpecification {}
 
 impl HasLastUpdate for ProductSpecification {
-    fn set_last_update(&mut self, time : String) {
-        self.last_update = Some(time);
+    fn set_last_update(&mut self, time : impl Into<String>) {
+        self.last_update = Some(time.into());
     }
 }
 
@@ -305,12 +305,12 @@ pub struct ProductSpecificationCharacteristicValueUse {
 
 impl ProductSpecificationCharacteristicValueUse {
     /// Create a new instance of ProductSpecificationCharacteristicValueUse
-    pub fn new(name : String) -> ProductSpecificationCharacteristicValueUse {
+    pub fn new(name : impl Into<String>) -> ProductSpecificationCharacteristicValueUse {
         ProductSpecificationCharacteristicValueUse { 
             description: None, 
             max_cardinality: 1, 
             min_cardinality: 0, 
-            name, 
+            name : name.into(), 
             value_type: String::from("String"), 
             valid_for: None,
             product_spec_characteristic_value : None,

--- a/src/tmf622/product_order.rs
+++ b/src/tmf622/product_order.rs
@@ -30,8 +30,8 @@ pub struct ProductOrder {
 }
 
 impl HasLastUpdate for ProductOrder {
-    fn set_last_update(&mut self, time : String) {
-        self.order_date = Some(time);
+    fn set_last_update(&mut self, time : impl Into<String>) {
+        self.order_date = Some(time.into());
     }
 }
 

--- a/src/tmf632/individual.rs
+++ b/src/tmf632/individual.rs
@@ -34,9 +34,9 @@ impl CreateTMF<Individual> for Individual {}
 
 impl Individual {
     /// Create a new instance of indiviudal object
-    pub fn new(name : &str) -> Individual {
+    pub fn new(name : impl Into<String>) -> Individual {
         let mut ind = Individual::create();
-        ind.full_name = name.to_owned();
+        ind.full_name = name.into();
         // Need this as default would be None
         ind.related_party = Some(vec![]);
         ind.contact_medium = Some(vec![]);

--- a/src/tmf632/organization.rs
+++ b/src/tmf632/organization.rs
@@ -47,9 +47,9 @@ pub struct Organization {
 
 impl Organization {
     /// Create a new organization record with a name
-    pub fn new(name : String) -> Organization {
+    pub fn new(name : impl Into<String>) -> Organization {
         let mut org = Organization::create();
-        org.name = name;
+        org.name = name.into();
         org.related_party = Some(vec![]);
         org
     }

--- a/src/tmf633/service_candidate.rs
+++ b/src/tmf633/service_candidate.rs
@@ -19,9 +19,9 @@ pub struct ServiceCandidate {
 
 impl ServiceCandidate {
     /// Create new instance of Service Candidate
-    pub fn new(name : String) -> ServiceCandidate {
+    pub fn new(name : impl Into<String>) -> ServiceCandidate {
         let mut sc = ServiceCandidate::create_with_time();
-        sc.name = name;
+        sc.name = name.into();
         sc
     }
 }
@@ -57,8 +57,8 @@ impl HasId for ServiceCandidate {
 impl CreateTMF<ServiceCandidate> for ServiceCandidate {}
 
 impl HasLastUpdate for ServiceCandidate {
-    fn set_last_update(&mut self, time : String) {
-        self.last_update = Some(time);
+    fn set_last_update(&mut self, time : impl Into<String>) {
+        self.last_update = Some(time.into());
     }
 }
 

--- a/src/tmf634/resource_candidate.rs
+++ b/src/tmf634/resource_candidate.rs
@@ -20,9 +20,9 @@ pub struct ResourceCandidate {
 
 impl ResourceCandidate {
     /// Create a new ResourceCandidate instance
-    pub fn new(name : String) -> ResourceCandidate {
+    pub fn new(name : impl Into<String>) -> ResourceCandidate {
         let mut rc = ResourceCandidate::create_with_time();
-        rc.name = name;
+        rc.name = name.into();
         rc
     }
 
@@ -57,8 +57,8 @@ impl HasId for ResourceCandidate {
 impl CreateTMF<ResourceCandidate> for ResourceCandidate {}
 
 impl HasLastUpdate for ResourceCandidate {
-    fn set_last_update(&mut self, time : String) {
-        self.last_update = Some(time);
+    fn set_last_update(&mut self, time : impl Into<String>) {
+        self.last_update = Some(time.into());
     }
 }
 

--- a/src/tmf637/product.rs
+++ b/src/tmf637/product.rs
@@ -59,10 +59,10 @@ impl CreateTMF<Product> for Product {}
 
 impl Product {
     /// Create a new product object
-    pub fn new(name: String) -> Product {
+    pub fn new(name: impl Into<String>) -> Product {
         let mut product = Product::create();
         product.status = ProductStatusType::Created;
-        product.name = name;
+        product.name = name.into();
         product
     }
 }

--- a/src/tmf638/service.rs
+++ b/src/tmf638/service.rs
@@ -34,13 +34,13 @@ pub struct Service {
 
 impl Service {
     /// Create a new service object for the inventory
-    pub fn new(name : String) -> Service {
+    pub fn new(name : impl Into<String>) -> Service {
         let id = Uuid::new_v4().to_string();
         let href = format!("/{}/{}/{}/{}",LIB_PATH,MOD_PATH,SERVICE_PATH,id);
         Service {
             id:Some(id), 
             href: Some(href), 
-            name,
+            name : name.into(),
             state : ServiceStateType::Inactive,
         }
     }

--- a/src/tmf639/characteristic.rs
+++ b/src/tmf639/characteristic.rs
@@ -13,7 +13,7 @@ pub struct Characteristic {
 
 impl Characteristic {
     /// Create a new resource characteristic
-    pub fn new(name: String) -> Characteristic {
-        Characteristic { name, ..Default::default() }
+    pub fn new(name: impl Into<String>) -> Characteristic {
+        Characteristic { name : name.into(), ..Default::default() }
     }
 }

--- a/src/tmf639/resource.rs
+++ b/src/tmf639/resource.rs
@@ -85,9 +85,9 @@ impl CreateTMF<Resource> for Resource {}
 
 impl Resource {
     /// Create a new Resource Inventory record
-    pub fn new(name : &str) -> Resource {
+    pub fn new(name : impl Into<String>) -> Resource {
         let mut resource = Resource::create();
-        resource.name = name.to_owned();
+        resource.name = name.into();
         resource.resource_version = Some(RESOURCE_VERS.to_owned());
         resource    
     }

--- a/src/tmf646/appointment.rs
+++ b/src/tmf646/appointment.rs
@@ -66,9 +66,11 @@ impl HasId for Appointment {
 impl CreateTMF<Appointment> for Appointment {}
 
 impl HasLastUpdate for Appointment {
-    fn set_last_update(&mut self, time : String) {
-        self.last_update = Some(time.clone());
-        self.creation_date = Some(time);
+    fn set_last_update(&mut self, time : impl Into<String>) {
+        let time1 = time.into();
+        let time2 = time1.clone();
+        self.last_update = Some(time1);
+        self.creation_date = Some(time2);
     }
 }
 

--- a/src/tmf648/quote_price.rs
+++ b/src/tmf648/quote_price.rs
@@ -90,9 +90,9 @@ pub struct QuotePrice {
 
 impl QuotePrice {
     /// Create a new QuotePrice object with a given name
-    pub fn new(name : &str) -> QuotePrice {
+    pub fn new(name :impl Into<String>) -> QuotePrice {
         QuotePrice {
-            name : Some(name.to_owned()),
+            name : Some(name.into()),
             ..Default::default()
         }    
     }

--- a/src/tmf653/service_test.rs
+++ b/src/tmf653/service_test.rs
@@ -45,9 +45,9 @@ pub struct ServiceTest {
 
 impl ServiceTest {
     /// Create new ServiceTest
-    pub fn new(name : &str) -> ServiceTest {
+    pub fn new(name : impl Into<String>) -> ServiceTest {
         let mut st = ServiceTest::create();
-        st.name = Some(name.to_owned());
+        st.name = Some(name.into());
         st
     }
 }

--- a/src/tmf666/billing_account.rs
+++ b/src/tmf666/billing_account.rs
@@ -19,9 +19,9 @@ pub struct BillingAccount {
 
 impl BillingAccount {
     /// Create new Billing Account
-    pub fn new(name : &str) -> BillingAccount {
+    pub fn new(name :impl Into<String>) -> BillingAccount {
         let mut account = BillingAccount::create();
-        account.name = name.to_owned();
+        account.name = name.into();
         account
     }
 }
@@ -49,8 +49,8 @@ impl HasId for BillingAccount {
 
 impl CreateTMF<BillingAccount> for BillingAccount {}
 impl HasLastUpdate for BillingAccount {
-    fn set_last_update(&mut self, time : String) {
-        self.last_update = Some(time);
+    fn set_last_update(&mut self, time : impl Into<String>) {
+        self.last_update = Some(time.into());
     }
 }
 impl CreateTMFWithTime<BillingAccount> for BillingAccount {}

--- a/src/tmf669/party_role.rs
+++ b/src/tmf669/party_role.rs
@@ -25,9 +25,9 @@ pub struct PartyRole {
 
 impl PartyRole {
     /// Create new PartyRole with given name
-    pub fn new(name : &str) -> PartyRole {
+    pub fn new(name : impl Into<String>) -> PartyRole {
         let mut role = PartyRole::create();
-        role.name = name.to_owned();
+        role.name = name.into();
         role
     }
 

--- a/src/tmf673/geographic_address.rs
+++ b/src/tmf673/geographic_address.rs
@@ -31,9 +31,9 @@ pub struct GeographicAddress {
 
 impl GeographicAddress {
     /// Create a new Geographic Address
-    pub fn new(name : String) -> GeographicAddress {
+    pub fn new(name : impl Into<String>) -> GeographicAddress {
         let mut address = GeographicAddress::create();
-        address.name = name;
+        address.name = name.into();
         address
     }
 

--- a/src/tmf674/geographic_site.rs
+++ b/src/tmf674/geographic_site.rs
@@ -109,9 +109,9 @@ pub struct GeographicSite {
 
 impl GeographicSite {
     /// Create a new Geographic Site with a name
-    pub fn new(name : String) -> GeographicSite {
+    pub fn new(name : impl Into<String>) -> GeographicSite {
         let mut site = GeographicSite::create();
-        site.name = name;
+        site.name = name.into();
         site.calendar = Some(vec![]);
         site
     }


### PR DESCRIPTION
Updated any constructor functions (e.g. new()) to use impl Into<String> instead of requiring a specific type.

This has been implemented across all modules.