### PR TITLE
Add missing camelCase

### DIFF
--- a/src/tmf674/geographic_site_v4.rs
+++ b/src/tmf674/geographic_site_v4.rs
@@ -46,6 +46,7 @@ impl From<GeographicAddress> for PlaceRefOrValue {
 
 /// Relationship to other sites
 #[derive(Clone, Debug, Default, Deserialize, Serialize, HasValidity)]
+#[serde(rename_all = "camelCase")]
 pub struct GeographicSiteRelationship {
     id : String,
     href : String,
@@ -56,6 +57,7 @@ pub struct GeographicSiteRelationship {
 
 /// Definition of start and finish hours
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct HourPeriod {
     start_hour : String,
     end_hour : String,
@@ -63,6 +65,7 @@ pub struct HourPeriod {
 
 /// Calendar entry defining periodic status for site, e.g. opening hours
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CalendarPeriod {
     day : Option<String>,
     status : Option<String>,
@@ -173,6 +176,7 @@ pub enum GeographicSiteEventType {
 
 /// Container for the payload that generated the event
 #[derive(Clone,Debug,Default,Deserialize,Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct GeographicSiteEvent {
     /// Struct that this event relates to
     pub geographic_site: GeographicSite,

--- a/src/tmf674/geographic_site_v5.rs
+++ b/src/tmf674/geographic_site_v5.rs
@@ -37,6 +37,7 @@ impl From<GeographicAddress> for PlaceRefOrValue {
 
 /// Definition of start and finish hours
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct HourPeriod {
     start_hour : String,
     end_hour : String,
@@ -44,6 +45,7 @@ pub struct HourPeriod {
 
 /// Calendar entry defining periodic status for site, e.g. opening hours
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CalendarPeriod {
     day : Option<String>,
     status : Option<String>,
@@ -128,6 +130,7 @@ pub enum GeographicSiteEventType {
 
 /// Container for the payload that generated the event
 #[derive(Clone,Debug,Default,Deserialize,Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct GeographicSiteEvent {
     /// Struct that this event relates to
     pub geographic_site: GeographicSite,


### PR DESCRIPTION
This closes 91 by adding in camelCase directives for various structures that did not have it.

This allows correct conversion between snake case used by Rust structure fields and camelCase used by TMF JSON payloads.