### PR TITLE
Convert to code 127

### DIFF
--- a/examples/create_customer.rs
+++ b/examples/create_customer.rs
@@ -6,11 +6,21 @@ use tmflib::tmf632::organization_v4::Organization;
 #[cfg(feature = "tmf632-v5")]
 use tmflib::tmf632::organization_v5::Organization;
 
-fn main() {
-    let org = Organization::new("ACustomer");
-    let customer = Customer::new(org);
+use tmflib::HasId;
 
+fn main() {
+    // let org = Organization::new("ACustomer");
+    // let customer = Customer::new(org);
+
+    // dbg!(&customer);
+    let mut customer = Customer::default();
+    customer.set_id("1");
+    customer.generate_code(None);
+    customer.generate_href();
     dbg!(&customer);
 
-    println!("Customer Code: {}",customer.get_characteristic("code").unwrap().value);
+    customer.upgrade_to_code(None);
+    dbg!(customer);
+
+    // println!("Customer Code: {}",customer.get_characteristic("code").unwrap().value);
 }

--- a/src/tmf629/customer.rs
+++ b/src/tmf629/customer.rs
@@ -184,10 +184,12 @@ impl Customer {
     /// # Example
     /// ```
     /// # use tmflib::tmf629::{characteristic::Characteristic,customer::Customer};
+    /// # use tmflib::HasId;
     /// let mut cust = Customer::default();
-    /// let char = cust.upgrade_to_code();
+    /// cust.set_id("1");
+    /// let char = cust.upgrade_to_code(None);
     /// ```
-    pub fn update_to_code(&mut self,) -> Option<String> {
+    pub fn upgrade_to_code(&mut self,offset : Option<u32>) -> Option<String> {
         // Step 1, Create new Characteristic for old Id
         let old_id = Characteristic {
             name: String::from("Id"),
@@ -196,7 +198,7 @@ impl Customer {
         };
         self.replace_characteristic(old_id);
         // Step 2, generate new code
-        self.generate_code(None);
+        self.generate_code(offset);
         let code = self.get_characteristic("code")?;
         // Step 3, We can only set the id if code was found
         self.set_id(code.value.clone());
@@ -383,6 +385,20 @@ mod test {
         let test_char = customer.get_characteristic("weather");
 
         assert!(test_char.is_some());
+    }
+
+    #[test]
+    fn test_customer_upgrade_to_code() {
+        let mut customer = Customer::default();
+        customer.set_id("1");
+        let code = customer.upgrade_to_code(None).unwrap();
+
+        let char = customer.get_characteristic("code");
+
+        // Returned value should match "code" characteristic
+        assert_eq!(code,char.unwrap().value);
+        // Simlarly, the id should match the code
+        assert_eq!(code,customer.get_id());
     }
 }
 

--- a/src/tmf629/customer.rs
+++ b/src/tmf629/customer.rs
@@ -170,6 +170,39 @@ impl Customer {
     pub fn name(&mut self, name : String) {
         self.name = Some(name.clone());
     }
+
+    /// Upgrade the customer to a cryptographic code to replace a sequential Id.
+    /// Will return the newly generated cryptographic code.
+    /// Takes the following steps:
+    /// -   Moves existing ID into characteristic of 'Id'
+    /// -   Generate cryptographic code via [generate_code] 
+    /// -   Replace Id, with newly genreated code.
+    /// -   Returns new code.
+    /// 
+    /// # Returns
+    /// Will return the new code.
+    /// # Example
+    /// ```
+    /// # use tmflib::tmf629::{characteristic::Characteristic,customer::Customer};
+    /// let mut cust = Customer::default();
+    /// let char = cust.upgrade_to_code();
+    /// ```
+    pub fn update_to_code(&mut self,) -> Option<String> {
+        // Step 1, Create new Characteristic for old Id
+        let old_id = Characteristic {
+            name: String::from("Id"),
+            value_type: String::from("string"),
+            value: self.get_id(),
+        };
+        self.replace_characteristic(old_id);
+        // Step 2, generate new code
+        self.generate_code(None);
+        let code = self.get_characteristic("code")?;
+        // Step 3, We can only set the id if code was found
+        self.set_id(code.value.clone());
+        // Step 4, return new code
+        Some(code.value)
+    }
 }
 
 impl From<&Organization> for Customer {

--- a/tmflib-derive/Cargo.lock
+++ b/tmflib-derive/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.82"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ad3d49ab951a01fbaafe34f2ec74122942fe18a3f9814c3268f1bb72042131b"
+checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
 dependencies = [
  "unicode-ident",
 ]
@@ -22,9 +22,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.63"
+version = "2.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf5be731623ca1a1fb7d8be6f261a3be6d3e2337b8a1f97be944d020c8fcb704"
+checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "tmflib-derive"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/tmflib-derive/Cargo.toml
+++ b/tmflib-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tmflib-derive"
-version = "0.1.16"
+version = "0.1.17"
 edition = "2021"
 authors = ["Ryan Ruckley <rruckley@gmail.com>"]
 description = "Derive macro for the tmflib::HasId trait"
@@ -11,6 +11,6 @@ repository = "https://github.com/rruckley/tmflib"
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "1.0.82"
+proc-macro2 = "1.0.85"
 quote = "1.0.36"
-syn = "2.0.63"
+syn = "2.0.66"

--- a/tmflib-derive/src/lib.rs
+++ b/tmflib-derive/src/lib.rs
@@ -69,6 +69,8 @@ pub fn hasid_derive(input: TokenStream) -> TokenStream {
             }
             fn set_id(&mut self, id : impl Into<String>) {
                 self.id = Some(id.into());
+                // Since we have changed the Id, the href will be invalid.
+                self.generate_href();
             }
         }
 


### PR DESCRIPTION
Allow a sequential id to be upgraded to customer code.:

- Update TMFLIB-Dervie to update href after set_id()
- New fn() to generate new code and store old id
- Update example to show changes to customer object.