### PR TITLE
FIX: Unwrap empty party

### DIFF
--- a/examples/test_derive.rs
+++ b/examples/test_derive.rs
@@ -18,6 +18,9 @@ fn main() {
                 None => None,
             }
         },
-        None => {},
-    }
+        None => {
+            None
+        },
+    };
+    dbg!(rp);
 }

--- a/examples/test_derive.rs
+++ b/examples/test_derive.rs
@@ -1,0 +1,23 @@
+//! Test something
+//! 
+
+#[derive(Default)]
+struct Test {
+    vec : Option<Vec<String>>,
+}
+
+fn main() {
+    let mut test = Test::default();
+    test.vec = Some(vec!["A String".to_string()]);
+
+    let my_test = &test;
+    let rp = match my_test.vec.as_ref() {
+        Some(v) => {
+            match v.get(0) {
+                Some(i) => Some(i).cloned(),
+                None => None,
+            }
+        },
+        None => {},
+    }
+}

--- a/tmflib-derive/Cargo.lock
+++ b/tmflib-derive/Cargo.lock
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "tmflib-derive"
-version = "0.1.23"
+version = "0.1.25"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/tmflib-derive/Cargo.toml
+++ b/tmflib-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tmflib-derive"
-version = "0.1.24"
+version = "0.1.25"
 edition = "2021"
 authors = ["Ryan Ruckley <rruckley@gmail.com>"]
 description = "Derive macro for the tmflib::HasId trait"

--- a/tmflib-derive/src/lib.rs
+++ b/tmflib-derive/src/lib.rs
@@ -181,7 +181,14 @@ pub fn hasrelatedparty_derive(input: TokenStream) -> TokenStream {
                 self.related_party.as_mut().unwrap().push(party);
             }
             fn get_party(&self, idx : usize ) -> Option<&RelatedParty> {
-                self.related_party.as_ref().unwrap().get(idx)    
+                match self.related_party.as_ref() {
+                    Some(rp) => {
+                        // Simple return results of get()
+                        rp.get(idx)
+                    },
+                    None => None,
+                }
+                  
             }
             fn remove_party(&mut self, idx : usize) -> Result<RelatedParty,String> {
                 Ok(self.related_party.as_mut().unwrap().remove(idx))  


### PR DESCRIPTION
Fix bug by:

- Checking for optional related_party 
- If exists, return results of get()