### PR TITLE
Add RelatedEntity 

### DIFF
--- a/examples/create_document.rs
+++ b/examples/create_document.rs
@@ -1,10 +1,17 @@
 //! Create Document Example
 //! 
 use tmflib::tmf667::document::Document;
+use tmflib::tmf651::agreement::Agreement;
 
 fn main() {
+    let agreement = Agreement::new("My Aggreement");
+    
     let doc = Document::new("My Document")
-        .doc_type("PDF");
+        .doc_type("PDF")
+        .link(agreement);
+
+
+    // doc.link_entity(agreement);
 
     dbg!(doc);
 }

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -24,6 +24,7 @@ pub mod money;
 pub mod note;
 pub mod price;
 pub mod product;
+pub mod related_entity;
 pub mod related_party;
 pub mod related_place;
 pub mod tax_item;

--- a/src/common/related_entity.rs
+++ b/src/common/related_entity.rs
@@ -1,0 +1,34 @@
+//! Related Entity Module
+
+use serde::{Deserialize,Serialize};
+
+use crate::Uri;
+use crate::HasName;
+
+/// Reference to another TMF schema
+#[derive(Clone,Default,Debug,Deserialize,Serialize)]
+pub struct RelatedEntity {
+    /// Referenced Name
+    pub name : String,
+    /// Referenced Id
+    pub id : String,
+    /// Referenced HREF
+    pub href : Uri,
+    /// Referenced Role
+    pub role : Option<String>,
+    /// Referred Type
+    pub referred_type: String,
+}
+
+/// Generate a related entity from any TMF object that has implemented HasName trait
+impl<T : HasName> From<T> for RelatedEntity {
+    fn from (value: T) -> Self {
+        RelatedEntity {
+            name : value.get_name(),
+            id : value.get_id(),
+            href: value.get_href(),
+            referred_type: T::get_class(),
+            ..Default::default()
+        }
+    }
+}

--- a/src/common/related_entity.rs
+++ b/src/common/related_entity.rs
@@ -32,3 +32,26 @@ impl<T : HasName> From<T> for RelatedEntity {
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use crate::tmf651::agreement::Agreement;
+    use crate::{HasId,HasName};
+
+    use super::RelatedEntity;
+
+    const AGREEMENT_NAME : &str = "AnAgreement";
+
+    #[test]
+    fn test_relatedentity_from() {
+        let agreement = Agreement::new(AGREEMENT_NAME);
+        let agree_ref = &agreement;
+
+        let entity = RelatedEntity::from(agreement.clone());
+
+        assert_eq!(entity.name,agree_ref.get_name());
+        assert_eq!(entity.id,agree_ref.get_id().as_str());
+        assert_eq!(entity.href,agree_ref.get_href().as_str());
+        assert_eq!(entity.referred_type,Agreement::get_class());
+    }
+}

--- a/src/tmf667/document.rs
+++ b/src/tmf667/document.rs
@@ -120,6 +120,7 @@ impl From<AttachmentRefOrValue> for Document {
 #[cfg(test)]
 mod test {
     use crate::common::attachment::AttachmentRefOrValue;
+    use crate::tmf651::agreement::Agreement;
     use super::DocumentStatusType;
     use super::DOC_VERSION;
 
@@ -129,6 +130,7 @@ mod test {
     const DOC_NAME : &str  = "A Document";
     const DOC_TYPE : &str = "PDF";
     const DOC_STATE: &str = "\"Created\"";
+    const AGREEMENT_NAME : &str = "AnAgreement";
 
     #[test]
     fn test_document_new() {
@@ -175,5 +177,16 @@ mod test {
         let doc = Document::from(attachref.clone());
 
         assert_eq!(doc.get_name(),attachref.get_name());
+    }
+
+    #[test]
+    fn test_document_link() {
+        let agreement = Agreement::new(AGREEMENT_NAME);
+
+        let document = Document::new(AGREEMENT_NAME)
+            .link(agreement);
+
+        assert_eq!(document.related_entity.is_some(),true);
+        assert_eq!(document.related_entity.unwrap().first().is_some(),true);
     }
 }

--- a/src/tmf667/document.rs
+++ b/src/tmf667/document.rs
@@ -5,6 +5,8 @@ use crate::{
 };
 use tmflib_derive::{HasId,HasName,HasLastUpdate,HasRelatedParty,HasDescription};
 use crate::common::related_party::RelatedParty;
+use crate::common::related_entity::RelatedEntity;
+use crate::vec_insert;
 use serde::{Deserialize,Serialize};
 
 const CLASS_PATH : &str = "document";
@@ -56,7 +58,10 @@ pub struct Document {
     #[serde(skip_serializing_if = "Option::is_none")]
     creation_date: Option<DateTime>,
     // Referenced objects
+    /// Parties
     related_party: Option<Vec<RelatedParty>>,
+    /// Related Entities
+    related_entity : Option<Vec<RelatedEntity>>,
     /// Attachement
     attachment : AttachmentRefOrValue,
 }
@@ -87,6 +92,17 @@ impl Document {
     pub fn doc_type(mut self, r#type : impl Into<String>) -> Document {
         self.document_type = Some(r#type.into());
         self
+    }
+
+    /// Link another TMF entity during creation
+    pub fn link<T : HasName>(mut self, entity : T) -> Document {
+        self.link_entity(entity);
+        self
+    }
+
+    /// Link another TMF entity into this document
+    pub fn link_entity<T : HasName>(&mut self, entity : T) {
+        vec_insert(&mut self.related_entity,RelatedEntity::from(entity));
     }
 }
 


### PR DESCRIPTION
Added support for RelatedEntity:

- Create new common module RelatedEntity
- Create generic conversion function for any object implementing HasName
- Use in functions on Document
- Update example for Document to demonstrate use of generic function
- Add test cases for both Document and RelatedEntity