### PR TITLE
TMF666 AccountRef: Fix field access

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tmflib"
-version = "0.1.22"
+version = "0.1.23"
 edition = "2021"
 authors = ["Ryan Ruckley <rruckley@gmail.com>"]
 description = "Interface library for processing TMF payloads"
@@ -43,7 +43,7 @@ tmf724 = []
 tmf760 = []
 
 # Build all V4 APIs
-all-v4 = [
+all = [
     "tmf620",
     "tmf622",
     "tmf629",
@@ -74,20 +74,6 @@ all-v4 = [
     "tmf699",
     "tmf700",
     "tmf724",
-    "tmf760"
-]
-
-# Build V5 APIs
-all-v5 = [
-    "tmf620",
-    "tmf622",
-    "tmf629",
-    "tmf632",
-    "tmf637",
-    "tmf674",
-    "tmf678",
-    "tmf696",
-    "tmf699",
     "tmf760"
 ]
 
@@ -218,15 +204,15 @@ TMFC061 = ["common"]
 # Resource Configuration and Activation
 TMFC062 = ["common"]
 
-default = ["all-v4","build-V4"]
+default = ["all","build-V4"]
 
 [dependencies]
 chrono = "0.4.38"
 rust_iso4217 = "0.1.1"
 serde = { version = "1.0.210", features = ["derive"]}
-serde_json = "1.0.128"
+serde_json = "1.0.132"
 sha256 = { version = "1.5", default-features = false }
-uuid = { version = "1.8.0", features = ["v4"]}
+uuid = { version = "1.11.0", features = ["v4"]}
 tmflib-derive = { version = "0.1.28" }
 # tmflib-derive = { path = "tmflib-derive"}
 hex = "0.4.3"

--- a/src/tmf666/mod.rs
+++ b/src/tmf666/mod.rs
@@ -37,21 +37,28 @@ const MOD_PATH : &str = "accountManagement/v4";
 #[derive( Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AccountRef {
-    description: Option<String>,
-    href: String,
-    id: String,
-    name : String,
+    /// Referenced Account Description
+    pub description: Option<String>,
+    /// Referenced Account HREF
+    pub href: String,
+    /// Referenced Account Unique Id
+    pub id: String,
+    /// Referenced Account Name
+    pub name : String,
 }
 
 /// Account Relationship
 #[derive( Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AccountRelationship {
-    relationship_type: String,
+    /// Account Relationship Type
+    pub relationship_type: String,
+    /// Account Relationship Validity
     #[serde(skip_serializing_if = "Option::is_none")]
-    valid_for: Option<TimePeriod>,
+    pub valid_for: Option<TimePeriod>,
+    /// Linked Account 
     #[serde(skip_serializing_if = "Option::is_none")]
-    account: Option<AccountRef>,
+    pub account: Option<AccountRef>,
 }
 
 /// Account Balance


### PR DESCRIPTION
Fixed field access by:

- Made all fields public as there are not access functions for a reference struct.