### PR TITLE
ServiceSpecification: Fix class path

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ allow_dirty = true
 
 [package]
 name = "tmflib"
-version = "0.1.24"
+version = "0.1.25"
 edition = "2021"
 authors = ["Ryan Ruckley <rruckley@gmail.com>"]
 description = "Interface library for processing TMF payloads"
@@ -214,7 +214,7 @@ default = ["all","build-V4"]
 chrono = "0.4.39"
 rust_iso4217 = "0.1.1"
 serde = { version = "1.0.217", features = ["derive"]}
-serde_json = "1.0.134"
+serde_json = "1.0.135"
 sha256 = { version = "1.5", default-features = false }
 uuid = { version = "1.11.0", features = ["v4"]}
 tmflib-derive = { version = "0.1.29" }

--- a/src/tmf633/service_specification.rs
+++ b/src/tmf633/service_specification.rs
@@ -9,7 +9,7 @@ use tmflib_derive::{HasId,HasName,HasLastUpdate,HasDescription};
 use super::MOD_PATH;
 use crate::LIB_PATH;
 
-const CLASS_PATH : &str = "service";
+const CLASS_PATH : &str = "serviceSpecification";
 
 use super::characteristic_specification::CharacteristicSpecification;
 


### PR DESCRIPTION
Fixed the CLASS_PATH for ServiceSecification to align with TMF633 suggested path.