### PR TITLE
Bug: Remove panic for derive macros

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,3 @@
-[workspace]
-allow_dirty = true
-
 [package]
 name = "tmflib"
 version = "0.1.26"
@@ -219,8 +216,8 @@ serde = { version = "1.0.217", features = ["derive"]}
 serde_json = "1.0.138"
 sha256 = { version = "1.5", default-features = false }
 uuid = { version = "1.12.1", features = ["v4"]}
-tmflib-derive = { version = "0.1.30" }
-# tmflib-derive = { path = "tmflib-derive"}
+# tmflib-derive = { version = "0.1.30" }
+tmflib-derive = { path = "tmflib-derive"}
 hex = "0.4.3"
 base32 = "0.5.1"
 openapiv3 = "2.0.0"

--- a/src/tmf629/customer.rs
+++ b/src/tmf629/customer.rs
@@ -429,5 +429,13 @@ mod test {
         assert_eq!(segment.is_some(),true);
         assert_eq!(segment.unwrap(),CUSTOMER_SEGMENT);
     }
+
+    #[test]
+    fn test_customer_noid() {
+        let customer = Customer::default();
+
+        assert_eq!(customer.get_id(),String::default());
+        assert_eq!(customer.get_href(),String::default());
+    }
 }
 

--- a/tmflib-derive/Cargo.lock
+++ b/tmflib-derive/Cargo.lock
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "tmflib-derive"
-version = "0.1.30"
+version = "0.1.31"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/tmflib-derive/Cargo.toml
+++ b/tmflib-derive/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "tmflib-derive"
-version = "0.1.30"
+version = "0.1.31"
 edition = "2021"
 authors = ["Ryan Ruckley <rruckley@gmail.com>"]
 description = "Derive macro for the tmflib::HasId trait"

--- a/tmflib-derive/src/lib.rs
+++ b/tmflib-derive/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright [2024] [Ryan Ruckley]
+// Copyright [2025] [Ryan Ruckley]
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -53,10 +53,16 @@ pub fn hasid_derive(input: TokenStream) -> TokenStream {
                 self.href = href.into();
             }
             fn get_id(&self) -> String {
-                self.id.as_ref().unwrap().clone()
+                match self.id.as_ref() {
+                    Some(i) => i.clone(),
+                    None => String::default(),
+                }
             }
             fn get_href(&self) -> String {
-                self.href.as_ref().unwrap().clone()
+                match self.href().as_ref() {
+                    Some(h) => h.clone(),
+                    None => String::default(),
+                }
             }
             fn get_class() -> String {
                 CLASS_PATH.to_string()

--- a/tmflib-derive/src/lib.rs
+++ b/tmflib-derive/src/lib.rs
@@ -59,7 +59,7 @@ pub fn hasid_derive(input: TokenStream) -> TokenStream {
                 }
             }
             fn get_href(&self) -> String {
-                match self.href().as_ref() {
+                match self.href.as_ref() {
                     Some(h) => h.clone(),
                     None => String::default(),
                 }


### PR DESCRIPTION
# Details
Updated macros for HasId trait:

- get_id() now checks for presence of Id and if None returns empty string.
- get_href() now checks for presense of href and if None returns empty string.
- Added unit test on TMF629 to ensure no panic occurs when id or href are not set.