### PR TITLE
Fix: TMF633 use vec_insert() for add_char()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tmflib"
-version = "0.1.27"
+version = "0.1.28"
 edition = "2021"
 authors = ["Ryan Ruckley <rruckley@gmail.com>"]
 description = "Interface library for processing TMF payloads"

--- a/src/tmf633/service_specification.rs
+++ b/src/tmf633/service_specification.rs
@@ -2,7 +2,7 @@
 
 use serde::{Deserialize,Serialize};
 
-use crate::{HasId,HasName,HasLastUpdate,HasDescription, TimePeriod};
+use crate::{HasId,HasName,HasLastUpdate,HasDescription, TimePeriod,vec_insert};
 use crate::common::related_party::RelatedParty;
 use tmflib_derive::{HasId,HasName,HasLastUpdate,HasDescription};
 
@@ -72,7 +72,7 @@ impl ServiceSpecification {
 
     /// Add a characteristic to this service specification
     pub fn add_char(&mut self, characteristic : CharacteristicSpecification) {
-        self.spec_characteristics.as_mut().unwrap().push(characteristic);
+        vec_insert(&mut self.spec_characteristics,characteristic);
     }
 }
 


### PR DESCRIPTION
# Fix
Fixed bug by updating add_char() to use the safe vec_insert() function to add a new characteristic.
# Testing
Reran example code to validate fix worked.